### PR TITLE
Added new fields to Melodies model to offer additional information on the raag

### DIFF
--- a/app/database/migrations/2015_02_11_025217_edit_melodies_table.php
+++ b/app/database/migrations/2015_02_11_025217_edit_melodies_table.php
@@ -1,0 +1,44 @@
+<?php
+
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Database\Migrations\Migration;
+
+class EditMelodiesTable extends Migration {
+
+	/**
+	 * Run the migrations.
+	 *
+	 * @return void
+	 */
+	public function up()
+	{
+		Schema::table('melodies', function(Blueprint $table)
+		{
+			$table->string('parent_melody');
+			$table->string('class');
+			$table->string('time');
+			$table->string('primary_note');
+			$table->string('secondary_note');
+			$table->string('forbidden_note');
+			$table->string('ascending_scale');
+			$table->string('descening_scale');
+			$table->string('characteristic_scale');
+			$table->string('information');
+			
+		});
+	}
+
+	/**
+	 * Reverse the migrations.
+	 *
+	 * @return void
+	 */
+	public function down()
+	{
+		Schema::table('melodies', function(Blueprint $table)
+		{
+			//
+		});
+	}
+
+}


### PR DESCRIPTION
Proposing additional fields to the Melodies table that will contain additional information on the raag, of a musical nature. This information is crucial for the individual reading/singing a given shabad who wishes to sing it as prescribed by the Guru. A suggested and reputable datasource would be vismaadnaad.org (an example can be found here: http://vismaadnaad.org/Siree-Raag.php)

Also, as an aside, since some shabads in Sri Guru Granth Sahib Ji have also been assigned a 'ghar' (tabla taal), a complete database ought to account for that information as well. A table such as Rhythm would work, although most shabads would get a null value for associated Rhythm.
